### PR TITLE
🔧 (fix): Remove metadata.yaml volume mount to fix Coolify deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,6 @@ services:
       - PUBLIC_URL=${PUBLIC_URL}
     volumes:
       - ./games.db:/app/games.db
-      - ./metadata.yaml:/app/metadata.yaml
     networks:
       - default
     restart: unless-stopped


### PR DESCRIPTION
- Coolify auto-generates metadata.yaml in application directory
- Manual mount causes directory/file type mismatch
- Let Coolify handle metadata file creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)