### PR TITLE
🔧 (fix): Remove database volume mounts for Coolify compatibility

### DIFF
--- a/Dockerfile.datasette.coolify
+++ b/Dockerfile.datasette.coolify
@@ -12,9 +12,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir uv \
     && uv pip install --system --prerelease=allow datasette datasette-write-ui sqlite-utils
 
-# Copy only the database file
-COPY games.db .
-COPY metadata.yaml .
+# Database files will be mounted by Coolify
 
 # Default command for production
 CMD ["datasette", "games.db", "--host", "0.0.0.0", "--port", "8001", "--metadata", "metadata.yaml"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
       - GAMES_DATABASE_NAME=/app/games.db
     volumes:
       - ./data:/app/data
-      - ./games.db:/app/games.db
-      - ./db.sqlite3:/app/db.sqlite3
     depends_on:
       - datasette
     networks:
@@ -35,7 +33,6 @@ services:
     environment:
       - PUBLIC_URL=${PUBLIC_URL}
     volumes:
-      - ./games.db:/app/games.db
     networks:
       - default
     restart: unless-stopped


### PR DESCRIPTION
- Let Coolify handle database file mounting through environment variables
- Remove explicit volume mounts for games.db and db.sqlite3
- Update Dockerfile.datasette.coolify to skip copying database files
- Coolify will mount the database files at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)