### PR TITLE
🔧 (fix): Remove nginx config volume mount for Coolify

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,9 +42,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    volumes:
-      - ./nginx.coolify.conf:/etc/nginx/nginx.conf
-      - ./ssl:/etc/nginx/ssl
+    # Coolify will handle nginx config automatically
     depends_on:
       - django
       - datasette


### PR DESCRIPTION
- Let Coolify handle nginx configuration automatically
- Remove volume mounts for nginx.coolify.conf and ssl
- Coolify provides its own nginx configuration for routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)