### PR TITLE
✅ (fix): Include games.db in Datasette build context

### DIFF
--- a/Dockerfile.datasette.coolify
+++ b/Dockerfile.datasette.coolify
@@ -12,8 +12,9 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir uv \
     && uv pip install --system --prerelease=allow datasette datasette-write-ui sqlite-utils
 
-# Copy metadata file
+# Copy metadata file and database
 COPY metadata.yaml .
+COPY games.db .
 
 # Default command for production
 CMD ["datasette", "games.db", "--host", "0.0.0.0", "--port", "8001", "--metadata", "metadata.yaml"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,8 +29,6 @@ services:
       dockerfile: Dockerfile.datasette.coolify
     environment:
       - PUBLIC_URL=${PUBLIC_URL}
-    volumes:
-      - ./games.db:/app/games.db
     networks:
       - default
     restart: unless-stopped


### PR DESCRIPTION
- Copy games.db directly in Dockerfile instead of volume mount
- Remove volume mount that was causing file not found
- Datasette can now start with proper database file
- Fixes "no available server" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)