### PR TITLE
🔥 (drastic): Simplify Coolify config to bare minimum

### DIFF
--- a/Dockerfile.datasette.coolify
+++ b/Dockerfile.datasette.coolify
@@ -12,9 +12,5 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir uv \
     && uv pip install --system --prerelease=allow datasette datasette-write-ui sqlite-utils
 
-# Copy metadata file and database
-COPY metadata.yaml .
-COPY games.db .
-
 # Default command for production
-CMD ["datasette", "games.db", "--host", "0.0.0.0", "--port", "8001", "--metadata", "metadata.yaml"]
+CMD ["datasette", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,10 +18,7 @@ services:
     networks:
       - default
     restart: unless-stopped
-    command: >
-      sh -c "python manage.py migrate &&
-             python manage.py collectstatic --noinput &&
-             gunicorn --bind 0.0.0.0:8000 core.wsgi:application"
+    command: gunicorn --bind 0.0.0.0:8000 core.wsgi:application
 
   datasette:
     build:
@@ -32,7 +29,7 @@ services:
     networks:
       - default
     restart: unless-stopped
-    command: datasette games.db --host 0.0.0.0 --port 8001 --metadata metadata.yaml
+    command: datasette --host 0.0.0.0 --port 8001
 
 networks:
   default:


### PR DESCRIPTION
- Remove all volume mounts and complex configurations
- Datasette runs without metadata.yaml or games.db (empty instance)
- Django runs without migrate/load_dates (will need manual setup)
- Focus on getting containers running first, then add complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)