### PR TITLE
🔧 (fix): Fix YAML syntax in datasette command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,8 @@ services:
     networks:
       - coolify
     restart: unless-stopped
-    command: datasette --host 0.0.0.0 --port 8001 --metadata metadata.yaml :memory:
+    command: >
+      sh -c "datasette --host 0.0.0.0 --port 8001 --metadata metadata.yaml :memory:"
 
 networks:
   coolify:


### PR DESCRIPTION
- Use multiline command format for proper YAML syntax
- Fix command escaping for Datasette startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)