### PR TITLE
🐳 (docker): fix sqlite file permissions in Django container

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -33,10 +33,13 @@ COPY games/ games/
 # Collect static files (using temporary SECRET_KEY for build)
 RUN SECRET_KEY=build-key python manage.py collectstatic --noinput --clear
 
-# Create non-root user for security
+# Copy entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Create non-root user for security (but run as root for volume permission handling)
 RUN useradd --create-home --shell /bin/bash django && \
     chown -R django:django /app
-USER django
 
 # Expose port
 EXPOSE 8000
@@ -45,5 +48,6 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:8000/admin/ || exit 1
 
-# Start Django with Gunicorn
+# Use entrypoint to fix permissions and start Django
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["gunicorn", "core.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Fix permissions on mounted volumes (skip read-only files)
+echo "Setting permissions on /app..."
+chown -R django:django /app 2>/dev/null || true
+
+# Ensure db.sqlite3 is writable by django user if it exists
+if [ -f /app/db.sqlite3 ]; then
+    chmod 664 /app/db.sqlite3 2>/dev/null || true
+fi
+
+# Run the command passed to the container
+exec "$@"


### PR DESCRIPTION
Add entrypoint script to fix permissions on mounted volumes, allowing the django process to read/write to db.sqlite3 even when volumes are mounted with root ownership from the host.

- Create entrypoint.sh that ensures /app is owned by django user
- Skip errors for read-only mounts (games.db)
- Ensure db.sqlite3 has proper write permissions
- Update Dockerfile.django to use entrypoint script

This fixes 500 errors on Coolify caused by sqlite files being inaccessible due to root ownership.