### PR TITLE
📝 Remove dangling .env.example reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ Use `null` for seasons where the playoff season hasn't been created yet:
 AHL_SEASON_PAIRS={"77": 80, "81": 84, "86": 88, "90": null}
 ```
 
-See `.env.example` for complete configuration options.
-
 ### Deployment
 
 **Environment Variables:**


### PR DESCRIPTION
The README pointed to `.env.example` ("See `.env.example` for complete configuration options"), but no such file exists in the repo. The only config variable (`AHL_SEASON_PAIRS`) is already documented inline just above, so the dead reference is removed.

Note: this PR intentionally does **not** touch the stale `just` command list or the "Features" stats (season/game/player counts) — those need your input and were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)